### PR TITLE
fix: CPCLOUD-2395 duplicate cookies & locale

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "dist/index.js",
   "author": "Sascha Fuchs <sascha.fuchs@webpros.com>",
   "license": "MIT",
-  "version": "2.1.42",
+  "version": "2.1.43",
   "engines": {
     "node": "18.x"
   },

--- a/src/components/feature/TSXUserProfile/TSXUserProfile.ce.vue
+++ b/src/components/feature/TSXUserProfile/TSXUserProfile.ce.vue
@@ -55,6 +55,14 @@ const inactiveFieldsArr: string[] = JSON.parse(props.inactiveFields)
 const cookies = useCookies(['locale'])
 const cookieLang = ref('')
 onMounted(() => {
+  if (!cookies.get('locale')) {
+    cookies.set('locale', cookies.get('i18n_redirected'), {
+      path: '/',
+      sameSite: 'lax',
+      maxAge: 31536000,
+      domain: `.${window.location.hostname}`
+    } )
+  }
   cookieLang.value = cookies.get('locale')
   setLanguage(cookieLang.value)
 })

--- a/src/composables/translateHelper.ts
+++ b/src/composables/translateHelper.ts
@@ -10,7 +10,8 @@ interface ILocales {
 }
 
 const currentLanguage = ref<string>('en')
-currentLanguage.value = useCookies(['locale']).get('locale') || 'en'
+const cookies = useCookies(['locale'])
+currentLanguage.value = cookies.get('i18n_redirected') || cookies.get('locale') || 'en'
 
 
 export function t (key: string, dynamicVars : null|{[key: string]: string} = null) : string {


### PR DESCRIPTION
CPCLOUD-2395 was not working correctly for the first time a user logged in (no locale was set until "changing" the language).
